### PR TITLE
Fix first build ninja missing rules for external libraries errors

### DIFF
--- a/cmake/tpls/DyninstElfUtils.cmake
+++ b/cmake/tpls/DyninstElfUtils.cmake
@@ -142,6 +142,21 @@ else()
         dyninst_message(FATAL_ERROR "ElfUtils will only build with the GNU compiler")
     endif()
 
+    set(_eu_root ${TPL_STAGING_PREFIX})
+    set(_eu_inc_dirs $<BUILD_INTERFACE:${_eu_root}/include>
+                     $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_INCLUDE_DIR}>)
+    set(_eu_lib_dirs $<BUILD_INTERFACE:${_eu_root}/lib>
+                     $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}>)
+    set(_eu_libs
+        $<BUILD_INTERFACE:${_eu_root}/lib/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
+        $<BUILD_INTERFACE:${_eu_root}/lib/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
+        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
+        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
+        )
+    set(_eu_build_byproducts
+        "${_eu_root}/lib/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}"
+        "${_eu_root}/lib/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
     include(ExternalProject)
     externalproject_add(
         ElfUtils-External
@@ -155,6 +170,7 @@ else()
             --enable-install-elfh --prefix=${TPL_STAGING_PREFIX} --disable-libdebuginfod
             --disable-debuginfod --enable-thread-safety
         BUILD_COMMAND make install
+        BUILD_BYPRODUCTS ${_eu_build_byproducts}
         INSTALL_COMMAND "")
 
     # target for re-executing the installation
@@ -163,18 +179,6 @@ else()
         COMMAND make install
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/elfutils/src/ElfUtils-External
         COMMENT "Installing ElfUtils...")
-
-    set(_eu_root ${TPL_STAGING_PREFIX})
-    set(_eu_inc_dirs $<BUILD_INTERFACE:${_eu_root}/include>
-                     $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_INCLUDE_DIR}>)
-    set(_eu_lib_dirs $<BUILD_INTERFACE:${_eu_root}/lib>
-                     $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}>)
-    set(_eu_libs
-        $<BUILD_INTERFACE:${_eu_root}/lib/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
-        $<BUILD_INTERFACE:${_eu_root}/lib/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
-        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
-        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
-        )
 endif()
 
 # -------------- EXPORT VARIABLES ---------------------------------------------

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -65,6 +65,17 @@ else()
     dyninst_message(STATUS "${LibIberty_ERROR_REASON}")
     dyninst_message(STATUS "Attempting to build LibIberty as external project")
 
+    set(_li_root ${TPL_STAGING_PREFIX})
+    set(_li_inc_dirs
+        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/binutils/src/LibIberty-External/include>)
+    set(_li_lib_dirs $<BUILD_INTERFACE:${_li_root}/lib>
+                     $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}>)
+    set(_li_libs
+        $<BUILD_INTERFACE:${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}>
+        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}>
+        )
+    set(_li_build_byproducts "${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
     include(ExternalProject)
     externalproject_add(
         LibIberty-External
@@ -76,6 +87,7 @@ else()
             CXX=${CMAKE_CXX_COMPILER} CXXFLAGS=-fPIC\ -O2\ -g <SOURCE_DIR>/configure
             --prefix=${PROJECT_BINARY_DIR}/binutils
         BUILD_COMMAND make
+        BUILD_BYPRODUCTS ${_li_build_byproducts}
         INSTALL_COMMAND "")
 
     add_custom_command(
@@ -97,16 +109,6 @@ else()
             ${TPL_STAGING_PREFIX}/lib
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/binutils/src/LibIberty-External
         COMMENT "Installing LibIberty...")
-
-    set(_li_root ${TPL_STAGING_PREFIX})
-    set(_li_inc_dirs
-        $<BUILD_INTERFACE:${PROJECT_BINARY_DIR}/binutils/src/LibIberty-External/include>)
-    set(_li_lib_dirs $<BUILD_INTERFACE:${_li_root}/lib>
-                     $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}>)
-    set(_li_libs
-        $<BUILD_INTERFACE:${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}>
-        $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}>
-        )
 
     # For backward compatibility
     set(IBERTY_FOUND TRUE)

--- a/cmake/tpls/DyninstTBB.cmake
+++ b/cmake/tpls/DyninstTBB.cmake
@@ -166,6 +166,7 @@ else()
 
         # Generate library filenames
         list(APPEND _tbb_libraries ${_tbb_${c}_lib})
+        list(APPEND _tbb_build_byproducts "${TPL_STAGING_PREFIX}/lib/lib${c}${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
         foreach(t RELEASE DEBUG)
             set(TBB_${c}_LIBRARY_${t}
@@ -217,6 +218,7 @@ else()
             [=[LDFLAGS=-Wl,-rpath='$$ORIGIN']=] ${MAKE_EXECUTABLE} -C src
             ${_tbb_components_cfg} tbb_build_dir=${_tbb_prefix_dir}/src
             tbb_build_prefix=tbb ${_tbb_compiler}
+        BUILD_BYPRODUCTS ${_tbb_build_byproducts}
         INSTALL_COMMAND "")
 
     # post-build target for installing build


### PR DESCRIPTION
The first build after configure no longer fails with messages like "ninja: error: 'tpls/lib/libboost_atomic.a', needed by 'common/libcommon.so.11.0.1', missing and no known rule to make it"

These were caused by ninja needing explicit rules for all targets even if order only dependencies ensure that they will be built before the consuming target. See
https://cmake.org/cmake/help/latest/policy/CMP0058.html for details.

ExternalProject_add uses add_custom_command under the hood and exposes the BYPRODUCTS option as BUILD_BYPRODUCTS. Use it to fix the errors.

Fixes https://github.com/AMDResearch/omnitrace/issues/219