### PR TITLE
Add CMake variable BINUTILS_DOWNLOAD_URL

### DIFF
--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -81,7 +81,7 @@ else()
         LibIberty-External
         PREFIX ${PROJECT_BINARY_DIR}/binutils
         URL
-          ${BINUTILS_DOWNLOAD_URL}
+          ${DYNINST_BINUTILS_DOWNLOAD_URL}
           http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz
           http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz
         BUILD_IN_SOURCE 1

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -76,11 +76,21 @@ else()
         )
     set(_li_build_byproducts "${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
+    # List of URLS (includes mirrors) to download binutils from.
+    set(TIMEMORY_BINUTILS_DOWNLOAD_URL
+        ""
+        CACHE STRING "URLs for binutils download")
+
+    # Add defualt URLs to download binutils from.
+    list(APPEND TIMEMORY_BINUTILS_DOWNLOAD_URL
+         "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz"
+         "http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz")
+
     include(ExternalProject)
     externalproject_add(
         LibIberty-External
         PREFIX ${PROJECT_BINARY_DIR}/binutils
-        URL http://ftpmirror.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz
+        URL ${TIMEMORY_BINUTILS_DOWNLOAD_URL}
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -77,12 +77,12 @@ else()
     set(_li_build_byproducts "${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
     # List of URLS (includes mirrors) to download binutils from.
-    set(TIMEMORY_BINUTILS_DOWNLOAD_URL
+    set(BINUTILS_DOWNLOAD_URL
         ""
         CACHE STRING "URLs for binutils download")
 
     # Add defualt URLs to download binutils from.
-    list(APPEND TIMEMORY_BINUTILS_DOWNLOAD_URL
+    list(APPEND BINUTILS_DOWNLOAD_URL
          "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz"
          "http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz")
 
@@ -90,7 +90,7 @@ else()
     externalproject_add(
         LibIberty-External
         PREFIX ${PROJECT_BINARY_DIR}/binutils
-        URL ${TIMEMORY_BINUTILS_DOWNLOAD_URL}
+        URL ${BINUTILS_DOWNLOAD_URL}
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -76,21 +76,14 @@ else()
         )
     set(_li_build_byproducts "${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
-    # List of URLS (includes mirrors) to download binutils from.
-    set(BINUTILS_DOWNLOAD_URL
-        ""
-        CACHE STRING "URLs for binutils download")
-
-    # Add defualt URLs to download binutils from.
-    list(APPEND BINUTILS_DOWNLOAD_URL
-         "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz"
-         "http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz")
-
     include(ExternalProject)
     externalproject_add(
         LibIberty-External
         PREFIX ${PROJECT_BINARY_DIR}/binutils
-        URL ${BINUTILS_DOWNLOAD_URL}
+        URL
+          ${BINUTILS_DOWNLOAD_URL}
+          http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz
+          http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/cmake/tpls/DyninstTBB.cmake
+++ b/cmake/tpls/DyninstTBB.cmake
@@ -211,7 +211,7 @@ else()
     externalproject_add(
         TBB-External
         PREFIX ${_tbb_prefix_dir}
-        URL https://github.com/01org/tbb/archive/${_tbb_ver_major}_U${_tbb_ver_minor}.tar.gz
+        URL https://github.com/ajanicijamd/oneTBB/archive/refs/tags/v${_tbb_ver_major}.${_tbb_ver_minor}.01.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND ""
         BUILD_COMMAND


### PR DESCRIPTION
This change is part of the fix for SWDEV-471917: in CI, we download binutils from artifactory. Outside CI, there are two mirrors from which cmake can download binutils: ftpmirror.gnu.org and mirrors.kernel.org.