### PR TITLE
Swdev 467873 dyninst patch

### DIFF
--- a/cmake/tpls/DyninstElfUtils.cmake
+++ b/cmake/tpls/DyninstElfUtils.cmake
@@ -162,6 +162,7 @@ else()
         PREFIX ${PROJECT_BINARY_DIR}/elfutils
         URL ${ElfUtils_DOWNLOAD_URL}
             "https://sourceware.org/elfutils/ftp/${ElfUtils_DOWNLOAD_VERSION}/elfutils-${ElfUtils_DOWNLOAD_VERSION}.tar.bz2"
+            "https://mirrors.kernel.org/sourceware/elfutils/${ElfUtils_DOWNLOAD_VERSION}/elfutils-${ElfUtils_DOWNLOAD_VERSION}.tar.bz2"
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/cmake/tpls/DyninstElfUtils.cmake
+++ b/cmake/tpls/DyninstElfUtils.cmake
@@ -145,16 +145,16 @@ else()
     set(_eu_root ${TPL_STAGING_PREFIX})
     set(_eu_inc_dirs $<BUILD_INTERFACE:${_eu_root}/include>
                      $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_INCLUDE_DIR}>)
-    set(_eu_lib_dirs $<BUILD_INTERFACE:${_eu_root}/lib>
+    set(_eu_lib_dirs $<BUILD_INTERFACE:${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}>
                      $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}>)
     set(_eu_libs
-        $<BUILD_INTERFACE:${_eu_root}/lib/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
-        $<BUILD_INTERFACE:${_eu_root}/lib/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
+        $<BUILD_INTERFACE:${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
+        $<BUILD_INTERFACE:${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
         $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
         $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
         )
-    set(_eu_build_byproducts "${_eu_root}/lib/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}"
-                             "${_eu_root}/lib/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(_eu_build_byproducts "${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                             "${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
     include(ExternalProject)
     externalproject_add(

--- a/cmake/tpls/DyninstElfUtils.cmake
+++ b/cmake/tpls/DyninstElfUtils.cmake
@@ -145,16 +145,16 @@ else()
     set(_eu_root ${TPL_STAGING_PREFIX})
     set(_eu_inc_dirs $<BUILD_INTERFACE:${_eu_root}/include>
                      $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_INCLUDE_DIR}>)
-    set(_eu_lib_dirs $<BUILD_INTERFACE:${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}>
+    set(_eu_lib_dirs $<BUILD_INTERFACE:${_eu_root}/${CMAKE_INSTALL_LIBDIR}>
                      $<INSTALL_INTERFACE:${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}>)
     set(_eu_libs
-        $<BUILD_INTERFACE:${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
-        $<BUILD_INTERFACE:${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
+        $<BUILD_INTERFACE:${_eu_root}/${CMAKE_INSTALL_LIBDIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
+        $<BUILD_INTERFACE:${_eu_root}/${CMAKE_INSTALL_LIBDIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
         $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}>
         $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/${INSTALL_LIB_DIR}/${TPL_INSTALL_LIB_DIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}>
         )
-    set(_eu_build_byproducts "${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}"
-                             "${_eu_root}/${CMAKE_DEFAULT_INSTALL_LIBDIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}")
+    set(_eu_build_byproducts "${_eu_root}/${CMAKE_INSTALL_LIBDIR}/libdw${CMAKE_SHARED_LIBRARY_SUFFIX}"
+                             "${_eu_root}/${CMAKE_INSTALL_LIBDIR}/libelf${CMAKE_SHARED_LIBRARY_SUFFIX}")
 
     include(ExternalProject)
     externalproject_add(

--- a/cmake/tpls/DyninstElfUtils.cmake
+++ b/cmake/tpls/DyninstElfUtils.cmake
@@ -160,7 +160,8 @@ else()
     externalproject_add(
         ElfUtils-External
         PREFIX ${PROJECT_BINARY_DIR}/elfutils
-        URL https://sourceware.org/elfutils/ftp/${ELFUTILS_DOWNLOAD_VERSION}/elfutils-${ELFUTILS_DOWNLOAD_VERSION}.tar.bz2
+        URL ${ElfUtils_DOWNLOAD_URL}
+            "https://sourceware.org/elfutils/ftp/${ElfUtils_DOWNLOAD_VERSION}/elfutils-${ElfUtils_DOWNLOAD_VERSION}.tar.bz2"
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -81,7 +81,7 @@ else()
         LibIberty-External
         PREFIX ${PROJECT_BINARY_DIR}/binutils
         URL
-          ${BINUTILS_DOWNLOAD_URL}
+          ${DYNINST_BINUTILS_DOWNLOAD_URL}
           http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz
           http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz
         BUILD_IN_SOURCE 1

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -76,11 +76,21 @@ else()
         )
     set(_li_build_byproducts "${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
+    # List of URLS (includes mirrors) to download binutils from.
+    set(TIMEMORY_BINUTILS_DOWNLOAD_URL
+        ""
+        CACHE STRING "URLs for binutils download")
+
+    # Add defualt URLs to download binutils from.
+    list(APPEND TIMEMORY_BINUTILS_DOWNLOAD_URL
+         "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz"
+         "http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz")
+
     include(ExternalProject)
     externalproject_add(
         LibIberty-External
         PREFIX ${PROJECT_BINARY_DIR}/binutils
-        URL http://ftpmirror.gnu.org/gnu/binutils/binutils-2.31.1.tar.gz
+        URL ${TIMEMORY_BINUTILS_DOWNLOAD_URL}
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -77,12 +77,12 @@ else()
     set(_li_build_byproducts "${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
     # List of URLS (includes mirrors) to download binutils from.
-    set(TIMEMORY_BINUTILS_DOWNLOAD_URL
+    set(BINUTILS_DOWNLOAD_URL
         ""
         CACHE STRING "URLs for binutils download")
 
     # Add defualt URLs to download binutils from.
-    list(APPEND TIMEMORY_BINUTILS_DOWNLOAD_URL
+    list(APPEND BINUTILS_DOWNLOAD_URL
          "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz"
          "http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz")
 
@@ -90,7 +90,7 @@ else()
     externalproject_add(
         LibIberty-External
         PREFIX ${PROJECT_BINARY_DIR}/binutils
-        URL ${TIMEMORY_BINUTILS_DOWNLOAD_URL}
+        URL ${BINUTILS_DOWNLOAD_URL}
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/cmake/tpls/DyninstLibIberty.cmake
+++ b/cmake/tpls/DyninstLibIberty.cmake
@@ -76,21 +76,14 @@ else()
         )
     set(_li_build_byproducts "${_li_root}/lib/libiberty${CMAKE_STATIC_LIBRARY_SUFFIX}")
 
-    # List of URLS (includes mirrors) to download binutils from.
-    set(BINUTILS_DOWNLOAD_URL
-        ""
-        CACHE STRING "URLs for binutils download")
-
-    # Add defualt URLs to download binutils from.
-    list(APPEND BINUTILS_DOWNLOAD_URL
-         "http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz"
-         "http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz")
-
     include(ExternalProject)
     externalproject_add(
         LibIberty-External
         PREFIX ${PROJECT_BINARY_DIR}/binutils
-        URL ${BINUTILS_DOWNLOAD_URL}
+        URL
+          ${BINUTILS_DOWNLOAD_URL}
+          http://ftpmirror.gnu.org/gnu/binutils/binutils-2.40.tar.gz
+          http://mirrors.kernel.org/sourceware/binutils/releases/binutils-2.40.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND
             ${CMAKE_COMMAND} -E env CC=${CMAKE_C_COMPILER} CFLAGS=-fPIC\ -O3

--- a/cmake/tpls/DyninstTBB.cmake
+++ b/cmake/tpls/DyninstTBB.cmake
@@ -211,7 +211,7 @@ else()
     externalproject_add(
         TBB-External
         PREFIX ${_tbb_prefix_dir}
-        URL https://github.com/01org/tbb/archive/${_tbb_ver_major}_U${_tbb_ver_minor}.tar.gz
+        URL https://github.com/ajanicijamd/oneTBB/archive/refs/tags/v${_tbb_ver_major}.${_tbb_ver_minor}.01.tar.gz
         BUILD_IN_SOURCE 1
         CONFIGURE_COMMAND ""
         BUILD_COMMAND


### PR DESCRIPTION
[SWDEV-467873](https://ontrack-internal.amd.com/browse/SWDEV-467873)
Making install library path configurable (lib or lib64).